### PR TITLE
Update get_styles to add line_wrap parameter

### DIFF
--- a/django_ansi2html_filter/templatetags/ansi.py
+++ b/django_ansi2html_filter/templatetags/ansi.py
@@ -14,4 +14,4 @@ def ansi(value):
 
 @register.simple_tag(name='ansi2html_styles')
 def ansi_styles(scheme='solarized', dark_bg=True):
-    return "\n".join(map(str, get_styles(dark_bg, scheme)[1:]))
+    return "\n".join(map(str, get_styles(dark_bg=dark_bg, line_wrap=True, scheme=scheme)[1:]))


### PR DESCRIPTION
ansi2html 1.9.2 has inserted a boolean `line_wrap` parameter to `get_styles`. This code was passing in two positional parameters, where the second parameter was a string. Leading to error message `tuple indices must be integers or slices, not str`.

This change adds the line_wrap parameter in the call to get_styles, and converts all parameters to kwargs, to better protect against additional future argument changes.

It will be a breaking change, losing support for older versions of ansi2html which do not have the line_wrap parameter.